### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,4 +1,7 @@
 name: build-container
+permissions:
+  contents: read
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/XCSoar/mapgen/security/code-scanning/5](https://github.com/XCSoar/mapgen/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
